### PR TITLE
fix(handler): 修复群私聊 @ 判定回归并增强链接提取稳定性

### DIFF
--- a/_manifest.json
+++ b/_manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 1,
   "name": "麦麦发 B 站视频",
-  "version": "1.3.5",
+  "version": "1.3.6",
   "description": "让麦麦解析 B 站视频链接并发送，群聊私聊都可用",
   "author": {
     "name": "XinxInxiN0",


### PR DESCRIPTION
- 调整链接提取流程：在启用小程序解析时优先使用 miniapp_card.source_url，未命中时回退 raw_message
- 修复 group_at_only 回归：@ 判定同时支持 raw_message CQ 码、additional_data(at_bot/is_mentioned) 与消息段 (mention_bot/at.qq)
- 优化 qn 提取来源：优先使用实际解析文本，失败时回退 raw_message
- 将 B 站处理器权重提升为 50，使其在 ON_MESSAGE 阶段更早执行

**注意**：若要解析小程序卡片，需关闭群聊中仅 @ 才回复，因为 QQ 无法做到发小程序卡片的同时 @