### PR TITLE
fix: remove dead code lines with unassigned get() calls

### DIFF
--- a/_manifest.json
+++ b/_manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 1,
   "name": "麦麦发 B 站视频",
-  "version": "1.4.2",
+  "version": "1.4.3",
   "description": "让麦麦解析 B 站视频链接并发送，群聊私聊都可用",
   "author": {
     "name": "XinxInxiN0",

--- a/plugin.py
+++ b/plugin.py
@@ -2879,7 +2879,7 @@ class BilibiliVideoSenderPlugin(BasePlugin):
     config_schema: Dict[str, Dict[str, ConfigField]] = {
         "plugin": {
             "enabled": ConfigField(type=bool, default=True, description="是否启用插件"),
-            "config_version": ConfigField(type=str, default="1.4.2", description="配置版本"),
+            "config_version": ConfigField(type=str, default="1.4.3", description="配置版本"),
             "use_new_events_manager": ConfigField(
                 type=bool,
                 default=True,

--- a/plugin.py
+++ b/plugin.py
@@ -2331,9 +2331,7 @@ class BilibiliAutoSendHandler(BaseEventHandler):
                 # 发送解析成功消息
                 success_message = "解析成功"
                 selected_qn_name = config_opts.get("selected_qn_name")
-                config_opts.get("requested_qn_name")
                 selected_qn = config_opts.get("selected_qn")
-                config_opts.get("requested_qn")
                 if selected_qn_name and selected_qn:
                     success_message = f"解析成功，已选择：{selected_qn_name}"
                 await self._send_text(success_message, stream_id)

--- a/plugin.py
+++ b/plugin.py
@@ -2879,7 +2879,7 @@ class BilibiliVideoSenderPlugin(BasePlugin):
     config_schema: Dict[str, Dict[str, ConfigField]] = {
         "plugin": {
             "enabled": ConfigField(type=bool, default=True, description="是否启用插件"),
-            "config_version": ConfigField(type=str, default="1.4.3", description="配置版本"),
+            "config_version": ConfigField(type=str, default="1.4.2", description="配置版本"),
             "use_new_events_manager": ConfigField(
                 type=bool,
                 default=True,


### PR DESCRIPTION
Lines 2334 and 2336 called config_opts.get() but discarded the return
values, making them no-ops. Remove these two useless statements.

https://claude.ai/code/session_01R14iwp7E6Fzcz3bNjMVZcf