### PR TITLE
fix: 修复自动清晰度静默降级 + SESSDATA 自动刷新

### DIFF
--- a/_manifest.json
+++ b/_manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 2,
   "id": "xinxinxin0.bilibili-video-sender",
-  "version": "2.0.1",
+  "version": "2.0.2",
   "name": "麦麦发 B 站视频",
   "description": "让麦麦解析 B 站视频链接并发送，群聊私聊都可用",
   "author": {

--- a/parser.py
+++ b/parser.py
@@ -261,6 +261,22 @@ class BilibiliParser:
         return best_video, selected_qn, "fallback" if fallback else "ok"
 
     @staticmethod
+    def _extract_refreshed_sessdata(response_headers: Any, current_sessdata: str) -> Optional[str]:
+        """从响应 Set-Cookie 中提取 B站刷新的 SESSDATA（与当前值不同时才返回）。"""
+        try:
+            cookies = response_headers.get_all("Set-Cookie") or []
+            for cookie in cookies:
+                for part in cookie.split(";"):
+                    part = part.strip()
+                    if part.upper().startswith("SESSDATA="):
+                        value = part[len("SESSDATA="):].strip()
+                        if value and value.lower() != "deleted" and value != current_sessdata:
+                            return value
+        except Exception:
+            pass
+        return None
+
+    @staticmethod
     def _build_request(url: str, headers: Optional[Dict[str, str]] = None) -> urllib.request.Request:
         default_headers = {
             "User-Agent": BilibiliParser.USER_AGENT,
@@ -444,6 +460,12 @@ class BilibiliParser:
             req = BilibiliParser._build_request(api, headers=headers)
             with urllib.request.urlopen(req, timeout=15) as resp:  # nosec - trusted public API
                 data_bytes = resp.read()
+                # 捕获 B站可能刷新的 SESSDATA（rolling session）
+                refreshed = BilibiliParser._extract_refreshed_sessdata(resp.headers, sessdata)
+                if refreshed:
+                    opts["sessdata"] = refreshed
+                    opts["sessdata_refreshed"] = True
+                    _logger.info("SESSDATA 已由 B站自动刷新")
         except Exception as e:
             _logger.error("HTTP请求失败: %s", e)
             return None, f"网络请求失败: {e}"
@@ -527,6 +549,17 @@ class BilibiliParser:
                     "Quality downgrade: requested %s (qn=%d), selected %s (qn=%d)",
                     BilibiliParser.get_qn_name(requested_qn),
                     requested_qn,
+                    selected_name,
+                    selected_qn,
+                )
+            elif requested_qn == 0 and selected_qn != qn:
+                # 自动模式：effective target 是 qn，但实际只拿到 selected_qn（低于预期）
+                # 通常因为 SESSDATA 过期或权限不足，B站退回游客级别的流
+                _logger.warning(
+                    "自动清晰度降级: 期望 %s (qn=%d)，实际获得 %s (qn=%d)，"
+                    "SESSDATA 可能已过期或账号权限不足，请在 config.toml 中更新 SESSDATA",
+                    BilibiliParser.get_qn_name(qn),
+                    qn,
                     selected_name,
                     selected_qn,
                 )
@@ -639,6 +672,12 @@ class BilibiliParser:
             req = BilibiliParser._build_request(api, headers=headers)
             with urllib.request.urlopen(req, timeout=15) as resp:  # nosec - trusted public API
                 data_bytes = resp.read()
+                # 捕获 B站可能刷新的 SESSDATA（rolling session）
+                refreshed = BilibiliParser._extract_refreshed_sessdata(resp.headers, sessdata)
+                if refreshed:
+                    opts["sessdata"] = refreshed
+                    opts["sessdata_refreshed"] = True
+                    _logger.info("Force DASH: SESSDATA 已由 B站自动刷新")
         except Exception as e:
             _logger.error("Force DASH HTTP error: %s", e)
             return None, f"Force DASH network error: {e}"
@@ -719,6 +758,16 @@ class BilibiliParser:
                     "Force DASH quality downgrade: requested %s (qn=%d), selected %s (qn=%d)",
                     BilibiliParser.get_qn_name(requested_qn),
                     requested_qn,
+                    selected_name,
+                    selected_qn,
+                )
+            elif requested_qn == 0 and selected_qn != qn:
+                # 自动模式：effective target 是 qn，但实际只拿到 selected_qn（低于预期）
+                _logger.warning(
+                    "Force DASH 自动清晰度降级: 期望 %s (qn=%d)，实际获得 %s (qn=%d)，"
+                    "SESSDATA 可能已过期或账号权限不足，请在 config.toml 中更新 SESSDATA",
+                    BilibiliParser.get_qn_name(qn),
+                    qn,
                     selected_name,
                     selected_qn,
                 )

--- a/plugin.py
+++ b/plugin.py
@@ -112,6 +112,7 @@ class BilibiliVideoSenderPlugin(MaiBotPlugin):
     config_reload_subscriptions: tuple[str, ...] = ()
 
     _bot_qq: str = ""
+    _cached_sessdata: str = ""  # 运行时内存缓存，B站 rolling session 刷新后更新
 
     async def on_load(self) -> None:
         """插件加载：预热 FFmpeg 缓存。"""
@@ -346,10 +347,12 @@ class BilibiliVideoSenderPlugin(MaiBotPlugin):
         # 预热 FFmpeg 缓存（check_ffmpeg_availability 幂等，结果已内部缓存）
         ffmpeg_manager.check_ffmpeg_availability()
 
+        # 优先使用内存缓存的 SESSDATA（B站 rolling session 刷新后更新）
+        effective_sessdata = self._cached_sessdata or str(self.config.bilibili.sessdata).strip()
         config_opts = {
             "qn": BilibiliParser.safe_int(self.config.bilibili.qn),
             "qn_strict": self.config.bilibili.qn_strict,
-            "sessdata": str(self.config.bilibili.sessdata).strip(),
+            "sessdata": effective_sessdata,
             "buvid3": str(self.config.bilibili.buvid3).strip(),
         }
 
@@ -412,6 +415,14 @@ class BilibiliVideoSenderPlugin(MaiBotPlugin):
         if not sources:
             return info, None, None, "error", f"解析失败：{status}"
 
+        # 若 B站在响应中刷新了 SESSDATA，更新内存缓存并持久化到 config.toml
+        if config_opts.get("sessdata_refreshed"):
+            new_sessdata = config_opts.get("sessdata", "")
+            if new_sessdata:
+                self._cached_sessdata = new_sessdata
+                self.ctx.logger.info("SESSDATA 内存缓存已更新（B站 rolling session）")
+                self._save_sessdata_to_config(new_sessdata)
+
         selected_qn_name = config_opts.get("selected_qn_name")
         return info, sources, selected_qn_name, status, None
 
@@ -454,6 +465,35 @@ class BilibiliVideoSenderPlugin(MaiBotPlugin):
             return compressed_path
 
         return temp_path
+
+    def _save_sessdata_to_config(self, new_sessdata: str) -> None:
+        """将 B站刷新的 SESSDATA 写回 config.toml，供插件重启后继续使用。"""
+        try:
+            config_path = os.path.join(os.path.dirname(__file__), "config.toml")
+            if not os.path.exists(config_path):
+                self.ctx.logger.warning("config.toml 不存在，SESSDATA 仅保留在内存缓存")
+                return
+            with open(config_path, "r", encoding="utf-8") as f:
+                lines = f.readlines()
+            in_bilibili = False
+            updated = False
+            new_lines = []
+            for line in lines:
+                stripped = line.strip()
+                if stripped.startswith("["):
+                    in_bilibili = (stripped == "[bilibili]")
+                if in_bilibili and not updated and re.match(r"\s*sessdata\s*=", line):
+                    line = re.sub(r'(".*?"|\'.*?\')', f'"{new_sessdata}"', line, count=1)
+                    updated = True
+                new_lines.append(line)
+            if updated:
+                with open(config_path, "w", encoding="utf-8") as f:
+                    f.writelines(new_lines)
+                self.ctx.logger.info("SESSDATA 已持久化到 config.toml")
+            else:
+                self.ctx.logger.warning("config.toml 中未找到 [bilibili].sessdata，无法持久化")
+        except Exception as e:
+            self.ctx.logger.warning("持久化 SESSDATA 失败: %s", e)
 
     @staticmethod
     def _cleanup_files(final_path: str, temp_path: str) -> None:


### PR DESCRIPTION
## Summary

- **静默降级问题**：`qn=0`（自动）模式下，若 B站因 SESSDATA 失效只返回 480P 流，原来仅打 INFO 日志 `Quality selected: requested_qn=0, selected_qn=32`，用户无从判断原因。现升级为 WARNING 并明确提示 SESSDATA 可能已失效
- **SESSDATA 自动刷新**：捕获 B站 rolling session 在响应 `Set-Cookie` 中下发的新 SESSDATA，写回 `config.toml` 并更新运行时内存缓存，减少手动更新频率

## Changes

- `parser.py`：新增 `_extract_refreshed_sessdata()` 静态方法；`get_play_urls` / `get_play_urls_force_dash` 两处新增降级 WARNING 分支和响应 cookie 捕获
- `plugin.py`：实例变量 `_cached_sessdata` 缓存刷新后的 SESSDATA；新增 `_save_sessdata_to_config()` 持久化方法

## Test plan

- [ ] 配置过期/失效 SESSDATA，触发 B 站视频链接，确认日志出现 WARNING 级别"自动清晰度降级"提示
- [ ] 配置有效 SESSDATA，确认日志仍为 INFO "Quality selected"，无误报
- [ ] 验证 B 站 rolling session 刷新时，config.toml 中 sessdata 字段被更新

🤖 Generated with [Claude Code](https://claude.com/claude-code)