### PR TITLE
补充插件配置 WebUI 元数据，并修复 NapCat video 消息超过 100 MiB 时发送失败的问题。

### DIFF
--- a/core/sender.py
+++ b/core/sender.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import asyncio
+import json
 import logging
 import os
 import urllib.parse
@@ -17,6 +18,7 @@ if TYPE_CHECKING:
     from ..plugin import ApiConfig
 
 _logger = logging.getLogger("plugin.bilibili_video_sender.sender")
+_NAPCAT_VIDEO_LIMIT_BYTES = 100 * 1024 * 1024
 
 
 async def send_text(
@@ -56,10 +58,22 @@ async def send_video(
         _logger.error("视频文件不存在: %s", original_path)
         return False
 
+    file_size = os.path.getsize(original_path)
+    if file_size > _NAPCAT_VIDEO_LIMIT_BYTES:
+        _logger.info(
+            "Video file exceeds NapCat video limit (%.2f MiB > 100 MiB), uploading as file",
+            file_size / (1024 * 1024),
+        )
+        return await _upload_file_via_onebot(original_path, converted_path, message, api_config)
+
     # MaiBot send_service 对 "video" custom type 无原生支持，会降级为 DictComponent，
     # 导致 QQ OneBot 适配器无法识别而静默丢弃消息（ctx.send.custom 不抛异常仍返回 True）。
     # 直接走 OneBot HTTP API，与旧版本行为一致。
-    return await _send_via_onebot(original_path, converted_path, message, api_config)
+    if await _send_via_onebot(converted_path, message, api_config):
+        return True
+
+    _logger.warning("Video message sending failed, falling back to file upload")
+    return await _upload_file_via_onebot(original_path, converted_path, message, api_config)
 
 
 async def _send_text_via_onebot(
@@ -143,73 +157,130 @@ async def _send_via_sdk(ctx: Any, file_uri: str, message: dict[str, Any]) -> boo
 
 
 async def _send_via_onebot(
+    converted_path: str,
+    message: dict[str, Any],
+    api_config: ApiConfig,
+) -> bool:
+    """直接通过 OneBot HTTP API 发送视频。"""
+    host = api_config.host
+    port = api_config.port
+    token = str(api_config.token).strip()
+    file_uri = _as_file_uri(converted_path)
+
+    is_private = _is_private_message(message)
+    if is_private:
+        user_id = _get_user_id(message)
+        if not user_id:
+            _logger.error("Private message but unable to get user ID")
+            return False
+        api_url = f"http://{host}:{port}/send_private_msg"
+        request_data = {"user_id": user_id, "message": [{"type": "video", "data": {"file": file_uri}}]}
+    else:
+        group_id = _get_group_id(message)
+        if not group_id:
+            _logger.error("Group message but unable to get group ID")
+            return False
+        api_url = f"http://{host}:{port}/send_group_msg"
+        request_data = {"group_id": group_id, "message": [{"type": "video", "data": {"file": file_uri}}]}
+
+    _logger.debug("OneBot video API: %s, data: %s", api_url, request_data)
+    return await _send_onebot_request(api_url, request_data, token, 300, "video")
+
+
+async def _upload_file_via_onebot(
     original_path: str,
     converted_path: str,
     message: dict[str, Any],
     api_config: ApiConfig,
 ) -> bool:
-    """直接通过 OneBot HTTP API 发送视频（fallback）。"""
+    """通过 OneBot 文件上传动作发送文件。"""
+    host = api_config.host
+    port = api_config.port
+    token = str(api_config.token).strip()
+    file_uri = _as_file_uri(converted_path)
+    file_name = os.path.basename(original_path) or "bilibili_video.mp4"
+
+    is_private = _is_private_message(message)
+    if is_private:
+        user_id = _get_user_id(message)
+        if not user_id:
+            _logger.error("Private message but unable to get user ID")
+            return False
+        api_url = f"http://{host}:{port}/upload_private_file"
+        request_data = {"user_id": user_id, "file": file_uri, "name": file_name, "upload_file": True}
+    else:
+        group_id = _get_group_id(message)
+        if not group_id:
+            _logger.error("Group message but unable to get group ID")
+            return False
+        api_url = f"http://{host}:{port}/upload_group_file"
+        request_data = {"group_id": group_id, "file": file_uri, "name": file_name, "upload_file": True}
+
+    _logger.debug("OneBot file API: %s, data: %s", api_url, request_data)
+    return await _send_onebot_request(api_url, request_data, token, 300, "file")
+
+
+async def _send_onebot_request(
+    api_url: str,
+    request_data: dict[str, Any],
+    token: str,
+    timeout: int,
+    action_name: str,
+) -> bool:
+    headers = {}
+    if token:
+        headers["Authorization"] = f"Bearer {token}"
+
     try:
-        host = api_config.host
-        port = api_config.port
-        token = str(api_config.token).strip()
-
-        file_uri = converted_path
-        if not converted_path.startswith(("http://", "https://", "file://")):
-            file_uri = "file:///" + urllib.request.pathname2url(converted_path).lstrip("/")
-
-        # 判断消息类型
-        is_private = _is_private_message(message)
-        if is_private:
-            user_id = _get_user_id(message)
-            if not user_id:
-                _logger.error("Private message but unable to get user ID")
-                return False
-            api_url = f"http://{host}:{port}/send_private_msg"
-            request_data = {"user_id": user_id, "message": [{"type": "video", "data": {"file": file_uri}}]}
-        else:
-            group_id = _get_group_id(message)
-            if not group_id:
-                _logger.error("Group message but unable to get group ID")
-                return False
-            api_url = f"http://{host}:{port}/send_group_msg"
-            request_data = {"group_id": group_id, "message": [{"type": "video", "data": {"file": file_uri}}]}
-
-        _logger.debug("OneBot API: %s, data: %s", api_url, request_data)
-
-        headers = {}
-        if token:
-            headers["Authorization"] = f"Bearer {token}"
-
         async with aiohttp.ClientSession() as session:
-            async with session.post(api_url, json=request_data, headers=headers, timeout=300) as response:
-                if response.status == 200:
-                    result = await response.json()
-                    _logger.debug("Video sent successfully via OneBot: %s", result)
-                    return True
-
-                if response.status in (401, 403) and token:
-                    _logger.warning("OneBot auth failed (%d), retrying with access_token", response.status)
-                    retry_url = f"{api_url}?access_token={urllib.parse.quote(token)}"
-                    async with session.post(retry_url, json=request_data, headers=headers, timeout=300) as retry_resp:
-                        if retry_resp.status == 200:
-                            result = await retry_resp.json()
-                            _logger.debug("Video sent successfully via OneBot (retry): %s", result)
-                            return True
-                        error_text = await retry_resp.text()
-                        _logger.error("Failed to send video (retry): HTTP %d, %s", retry_resp.status, error_text)
-                        return False
-
-                error_text = await response.text()
-                _logger.error("Failed to send video: HTTP %d, %s", response.status, error_text)
-                return False
-
+            status, body = await _post_onebot(session, api_url, request_data, headers, timeout)
+            if status in (401, 403) and token:
+                _logger.warning("OneBot auth failed (%d), retrying with access_token", status)
+                retry_url = f"{api_url}?access_token={urllib.parse.quote(token)}"
+                status, body = await _post_onebot(session, retry_url, request_data, headers, timeout)
+            return _onebot_result_ok(action_name, status, body)
     except asyncio.TimeoutError:
-        _logger.error("Video sending timeout")
+        _logger.error("OneBot %s sending timeout", action_name)
         return False
     except Exception as e:
-        _logger.error("Video sending error: %s", e)
+        _logger.error("OneBot %s sending error: %s", action_name, e)
         return False
+
+
+async def _post_onebot(
+    session: aiohttp.ClientSession,
+    api_url: str,
+    request_data: dict[str, Any],
+    headers: dict[str, str],
+    timeout: int,
+) -> tuple[int, str]:
+    async with session.post(api_url, json=request_data, headers=headers, timeout=timeout) as response:
+        return response.status, await response.text()
+
+
+def _onebot_result_ok(action_name: str, status: int, body: str) -> bool:
+    if status != 200:
+        _logger.error("Failed to send %s: HTTP %d, %s", action_name, status, body)
+        return False
+
+    try:
+        result = json.loads(body) if body else {}
+    except json.JSONDecodeError:
+        _logger.error("Failed to send %s: invalid OneBot response %s", action_name, body)
+        return False
+
+    if result.get("status") == "ok" and result.get("retcode") in (0, "0"):
+        _logger.debug("%s sent successfully via OneBot: %s", action_name.capitalize(), result)
+        return True
+
+    _logger.error("Failed to send %s: %s", action_name, result)
+    return False
+
+
+def _as_file_uri(path: str) -> str:
+    if path.startswith(("http://", "https://", "file://")):
+        return path
+    return "file:///" + urllib.request.pathname2url(path).lstrip("/")
 
 
 def _is_private_message(message: dict[str, Any]) -> bool:

--- a/plugin.py
+++ b/plugin.py
@@ -28,20 +28,60 @@ from .core.utils import ensure_shared_file_permissions, get_download_temp_dir
 # ── 配置模型 ─────────────────────────────────────────────────
 
 
+def _ui(label: str, hint: str, order: int, **extra: Any) -> dict[str, Any]:
+    """构造 WebUI 字段元数据。"""
+
+    metadata: dict[str, Any] = {"label": label, "hint": hint, "order": order}
+    metadata.update(extra)
+    return metadata
+
+
 class BilibiliAuthConfig(PluginConfigBase):
     """B站登录凭据配置。"""
     __ui_label__ = "B站认证"
     __ui_icon__ = "key"
     __ui_order__ = 1
 
-    SESSDATA: str = Field(default="", description="B站 SESSDATA Cookie")
-    bili_jct: str = Field(default="", description="B站 bili_jct Cookie")
-    DedeUserID: str = Field(default="", description="B站 DedeUserID Cookie")
-    DedeUserID__ckMd5: str = Field(default="", description="B站 DedeUserID__ckMd5 Cookie")
-    sid: str = Field(default="", description="B站 sid Cookie")
-    buvid3: str = Field(default="", description="B站 buvid3 Cookie")
-    buvid4: str = Field(default="", description="B站 buvid4 Cookie")
-    ac_time_value: str = Field(default="", description="B站 Local Storage 中的 ac_time_value")
+    SESSDATA: str = Field(
+        default="",
+        description="B站 SESSDATA Cookie",
+        json_schema_extra=_ui("SESSDATA", "B站 SESSDATA Cookie", 0),
+    )
+    bili_jct: str = Field(
+        default="",
+        description="B站 bili_jct Cookie",
+        json_schema_extra=_ui("bili_jct", "B站 bili_jct Cookie", 1),
+    )
+    DedeUserID: str = Field(
+        default="",
+        description="B站 DedeUserID Cookie",
+        json_schema_extra=_ui("DedeUserID", "B站 DedeUserID Cookie", 2),
+    )
+    DedeUserID__ckMd5: str = Field(
+        default="",
+        description="B站 DedeUserID__ckMd5 Cookie",
+        json_schema_extra=_ui("DedeUserID__ckMd5", "B站 DedeUserID__ckMd5 Cookie", 3),
+    )
+    sid: str = Field(
+        default="",
+        description="B站 sid Cookie",
+        json_schema_extra=_ui("sid", "B站 sid Cookie", 4),
+    )
+    buvid3: str = Field(
+        default="",
+        description="B站 buvid3 Cookie",
+        json_schema_extra=_ui("buvid3", "B站 buvid3 Cookie", 5),
+    )
+    buvid4: str = Field(
+        default="",
+        description="B站 buvid4 Cookie",
+        json_schema_extra=_ui("buvid4", "B站 buvid4 Cookie", 6),
+    )
+    ac_time_value: str = Field(
+        default="",
+        description="B站 Local Storage 中的 ac_time_value",
+        json_schema_extra=_ui("ac_time_value", "B站 Local Storage 中的 ac_time_value", 7),
+    )
 
 
 class BilibiliConfig(PluginConfigBase):
@@ -50,16 +90,65 @@ class BilibiliConfig(PluginConfigBase):
     __ui_icon__ = "videocam"
     __ui_order__ = 2
 
-    enable_cookie_refresh: bool = Field(default=True, description="是否启用 B 站 Cookie 主动续期")
-    qn: int = Field(default=0, description="清晰度设置(qn)，0 为自动（登录默认 720P，未登录默认 480P）", ge=0)
-    qn_strict: bool = Field(default=False, description="是否严格按 qn 选择清晰度")
-    group_at_only: bool = Field(default=False, description="群聊中仅当被 @ 时才处理 B 站链接")
-    block_ai_reply: bool = Field(default=True, description="检测到 B 站视频链接后是否阻止后续 AI 回复")
-    enable_video_compression: bool = Field(default=True, description="是否启用视频压缩功能")
-    max_video_size_mb: int = Field(default=100, description="视频文件大小限制（MB），超过此大小将进行压缩", ge=1)
-    compression_quality: int = Field(default=23, description="视频压缩质量 (1-51，数值越小质量越高)", ge=1, le=51)
-    enable_duration_limit: bool = Field(default=True, description="是否启用视频时长限制")
-    max_video_duration: int = Field(default=600, description="视频最大时长限制（秒），超过此时长将拒绝发送", ge=1)
+    enable_cookie_refresh: bool = Field(
+        default=True,
+        description="是否启用 B 站 Cookie 主动续期",
+        json_schema_extra=_ui(
+            "Cookie 主动续期",
+            "是否启用 B 站 Cookie 主动续期",
+            0,
+        ),
+    )
+    qn: int = Field(
+        default=0,
+        description="清晰度设置(qn)，0 为自动（登录默认 720P，未登录默认 480P）",
+        ge=0,
+        json_schema_extra=_ui("视频清晰度", "清晰度设置(qn)，0 为自动（登录默认 720P，未登录默认 480P）", 1),
+    )
+    qn_strict: bool = Field(
+        default=False,
+        description="是否严格按 qn 选择清晰度",
+        json_schema_extra=_ui("严格匹配清晰度", "是否严格按 qn 选择清晰度", 2),
+    )
+    group_at_only: bool = Field(
+        default=False,
+        description="群聊中仅当被 @ 时才处理 B 站链接",
+        json_schema_extra=_ui("群聊仅 @ 时处理", "群聊中仅当被 @ 时才处理 B 站链接", 3),
+    )
+    block_ai_reply: bool = Field(
+        default=True,
+        description="检测到 B 站视频链接后是否阻止后续 AI 回复",
+        json_schema_extra=_ui("拦截 AI 回复", "检测到 B 站视频链接后是否阻止后续 AI 回复", 4),
+    )
+    enable_video_compression: bool = Field(
+        default=True,
+        description="是否启用视频压缩功能",
+        json_schema_extra=_ui("视频压缩", "是否启用视频压缩功能", 5),
+    )
+    max_video_size_mb: int = Field(
+        default=100,
+        description="视频文件大小限制（MB），超过此大小将进行压缩",
+        ge=1,
+        json_schema_extra=_ui("视频大小上限", "视频文件大小限制（MB），超过此大小将进行压缩", 6),
+    )
+    compression_quality: int = Field(
+        default=23,
+        description="视频压缩质量 (1-51，数值越小质量越高)",
+        ge=1,
+        le=51,
+        json_schema_extra=_ui("压缩质量 CRF", "视频压缩质量 (1-51，数值越小质量越高)", 7),
+    )
+    enable_duration_limit: bool = Field(
+        default=True,
+        description="是否启用视频时长限制",
+        json_schema_extra=_ui("视频时长限制", "是否启用视频时长限制", 8),
+    )
+    max_video_duration: int = Field(
+        default=600,
+        description="视频最大时长限制（秒），超过此时长将拒绝发送",
+        ge=1,
+        json_schema_extra=_ui("最大视频时长", "视频最大时长限制（秒），超过此时长将拒绝发送", 9),
+    )
 
 
 class ParserConfig(PluginConfigBase):
@@ -67,7 +156,11 @@ class ParserConfig(PluginConfigBase):
     __ui_label__ = "解析器设置"
     __ui_order__ = 3
 
-    enable_miniapp_card: bool = Field(default=True, description="是否允许解析 B 站小卡片")
+    enable_miniapp_card: bool = Field(
+        default=True,
+        description="是否允许解析 B 站小卡片",
+        json_schema_extra=_ui("解析小程序卡片", "是否允许解析 B 站小卡片", 0),
+    )
 
 
 class FFmpegConfig(PluginConfigBase):
@@ -76,12 +169,29 @@ class FFmpegConfig(PluginConfigBase):
     __ui_icon__ = "build"
     __ui_order__ = 4
 
-    show_warnings: bool = Field(default=True, description="是否显示 FFmpeg 相关警告信息")
-    enable_hardware_acceleration: bool = Field(default=True, description="是否启用硬件加速自动检测")
-    force_encoder: str = Field(default="", description="强制使用特定编码器（留空则自动选择）")
+    show_warnings: bool = Field(
+        default=True,
+        description="是否显示 FFmpeg 相关警告信息",
+        json_schema_extra=_ui("显示 FFmpeg 警告", "是否显示 FFmpeg 相关警告信息", 0),
+    )
+    enable_hardware_acceleration: bool = Field(
+        default=True,
+        description="是否启用硬件加速自动检测",
+        json_schema_extra=_ui("硬件加速检测", "是否启用硬件加速自动检测", 1),
+    )
+    force_encoder: str = Field(
+        default="",
+        description="强制使用特定编码器（留空则自动选择）",
+        json_schema_extra=_ui("强制编码器", "强制使用特定编码器（留空则自动选择）", 2),
+    )
     encoder_priority: list[str] = Field(
         default=["nvidia", "intel", "amd", "apple"],
         description="编码器优先级（当检测到多个硬件编码器时的选择顺序）",
+        json_schema_extra=_ui(
+            "编码器优先级",
+            "编码器优先级（当检测到多个硬件编码器时的选择顺序）",
+            3,
+        ),
     )
 
 
@@ -93,10 +203,20 @@ class EnvironmentConfig(PluginConfigBase):
     runtime_mode: str = Field(
         default="windows",
         description="运行环境模式：windows = 纯 Windows 环境 | wsl = WSL 混合环境 | linux = 纯 Linux 环境",
+        json_schema_extra=_ui(
+            "运行环境模式",
+            "运行环境模式：windows = 纯 Windows 环境 | wsl = WSL 混合环境 | linux = 纯 Linux 环境",
+            0,
+        ),
     )
     linux_temp_dir: str = Field(
         default="",
         description="Linux 自定义视频临时目录（留空则使用插件目录 tmp；建议填写 NapCat 可读取的目录，如 /var/tmp/maibot_bilibili）",
+        json_schema_extra=_ui(
+            "Linux 临时目录",
+            "Linux 自定义视频临时目录（留空则使用插件目录 tmp；建议填写 NapCat 可读取的目录，如 /var/tmp/maibot_bilibili）",
+            1,
+        ),
     )
 
 
@@ -105,9 +225,23 @@ class ApiConfig(PluginConfigBase):
     __ui_label__ = "API设置"
     __ui_order__ = 6
 
-    host: str = Field(default="127.0.0.1", description="OneBot HTTP API 主机名/地址")
-    port: int = Field(default=5700, description="OneBot HTTP API 端口号", ge=1, le=65535)
-    token: str = Field(default="", description="OneBot HTTP API Token")
+    host: str = Field(
+        default="127.0.0.1",
+        description="OneBot HTTP API 主机名/地址",
+        json_schema_extra=_ui("OneBot API 主机", "OneBot HTTP API 主机名/地址", 0),
+    )
+    port: int = Field(
+        default=5700,
+        description="OneBot HTTP API 端口号",
+        ge=1,
+        le=65535,
+        json_schema_extra=_ui("OneBot API 端口", "OneBot HTTP API 端口号", 1),
+    )
+    token: str = Field(
+        default="",
+        description="OneBot HTTP API Token",
+        json_schema_extra=_ui("OneBot API Token", "OneBot HTTP API Token", 2),
+    )
 
 
 class PluginMetaConfig(PluginConfigBase):
@@ -115,19 +249,48 @@ class PluginMetaConfig(PluginConfigBase):
     __ui_label__ = "插件设置"
     __ui_order__ = 0
 
-    config_version: str = Field(default="2.0.6", description="配置版本（勿手动修改）")
-    enabled: bool = Field(default=True, description="是否启用插件")
+    config_version: str = Field(
+        default="2.0.6",
+        description="配置版本（勿手动修改）",
+        json_schema_extra=_ui("配置版本", "配置版本（勿手动修改）", 99),
+    )
+    enabled: bool = Field(
+        default=True,
+        description="是否启用插件",
+        json_schema_extra=_ui("启用插件", "是否启用插件", 0),
+    )
 
 
 class PluginConfig(PluginConfigBase):
     """插件总配置。"""
-    plugin: PluginMetaConfig = Field(default_factory=PluginMetaConfig)
-    auth: BilibiliAuthConfig = Field(default_factory=BilibiliAuthConfig)
-    bilibili: BilibiliConfig = Field(default_factory=BilibiliConfig)
-    parser: ParserConfig = Field(default_factory=ParserConfig)
-    ffmpeg: FFmpegConfig = Field(default_factory=FFmpegConfig)
-    environment: EnvironmentConfig = Field(default_factory=EnvironmentConfig)
-    api: ApiConfig = Field(default_factory=ApiConfig)
+    plugin: PluginMetaConfig = Field(
+        default_factory=PluginMetaConfig,
+        json_schema_extra=_ui("插件设置", "插件元配置（框架必需，勿删除）。", 0),
+    )
+    auth: BilibiliAuthConfig = Field(
+        default_factory=BilibiliAuthConfig,
+        json_schema_extra=_ui("B站认证", "B站登录凭据配置。", 1),
+    )
+    bilibili: BilibiliConfig = Field(
+        default_factory=BilibiliConfig,
+        json_schema_extra=_ui("B站设置", "B站 API 与视频处理配置。", 2),
+    )
+    parser: ParserConfig = Field(
+        default_factory=ParserConfig,
+        json_schema_extra=_ui("解析器设置", "解析器配置。", 3),
+    )
+    ffmpeg: FFmpegConfig = Field(
+        default_factory=FFmpegConfig,
+        json_schema_extra=_ui("FFmpeg设置", "FFmpeg 相关配置。", 4),
+    )
+    environment: EnvironmentConfig = Field(
+        default_factory=EnvironmentConfig,
+        json_schema_extra=_ui("环境设置", "运行环境配置。", 5),
+    )
+    api: ApiConfig = Field(
+        default_factory=ApiConfig,
+        json_schema_extra=_ui("API设置", "OneBot API 配置（视频发送 fallback 用）。", 6),
+    )
 
 
 # ── 插件主类 ─────────────────────────────────────────────────


### PR DESCRIPTION
- 为插件配置模型补充 WebUI 展示元数据，包括分组标题、排序、字段标签和提示信息。
- 修复 NapCat video 消息存在 100 MiB 硬限制时的发送回归：
  - 最终文件超过 100 MiB 时直接使用文件上传。
  - video 消息发送失败时降级为文件上传。
  - 按 OneBot 返回体 `status` / `retcode` 判断发送结果，避免 HTTP 200 被误判为成功。